### PR TITLE
Avoid double rendering

### DIFF
--- a/filterui/app/views/controls.js
+++ b/filterui/app/views/controls.js
@@ -39,19 +39,21 @@ var ControlsView = Backbone.View.extend({
     var genre = $("select[name='genre']").val();
     var that = this;
     if (genre === "all") {
-      that.collection.reset(that.superset.toJSON());
+      that.movies.reset(that.superset.toJSON());
     }
     else {
-      that.collection.reset(that.superset.toJSON());
+      // remove operation that causes unecessary rendering
       this.filterByCategory(genre);
     }
   },
 
   filterByCategory: function(genre) {
-     var filtered = this.movies.filter(function(m) { 
+    // since we need an untouched collection, we can use the superset
+     var filtered = this.superset.filter(function(m) { 
        return (_.indexOf(m.get('genres'), genre) !== -1)
      });
-     this.collection.reset(filtered);
+     
+     this.movies.reset(filtered);
   },
 
   sortByTitle: function(ev) {

--- a/filterui/app/views/controls.js
+++ b/filterui/app/views/controls.js
@@ -52,7 +52,6 @@ var ControlsView = Backbone.View.extend({
      var filtered = this.superset.filter(function(m) { 
        return (_.indexOf(m.get('genres'), genre) !== -1)
      });
-     
      this.movies.reset(filtered);
   },
 


### PR DESCRIPTION
Given the _this.superset_ (copy of original) collection, maybe we don't really need to reset _movies_ in order to have a fresh (filtered) collection. Moving this direction we avoid a not necessary double rendering of the view.
